### PR TITLE
Add a binary target for build size analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ name = "cshannon"
 path = "src/bin/cli.rs"
 required-features = ["cli"]
 
+[[bin]]
+name = "minbin"
+path = "src/bin/minbin.rs"
+
 [dev-dependencies]
 clap = { version = "4.5.51", features = ["derive"] }
 criterion = "0.7.0"

--- a/src/bin/minbin.rs
+++ b/src/bin/minbin.rs
@@ -1,0 +1,45 @@
+// Copyright 2020 Prathmesh Prabhu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This is a minimal binary built using the exported cshannon library from this
+//! crate.
+//!
+//! This binary will panic upon execution, because it does not properly setup
+//! the necessary environment for the library (in partiular, no logger is
+//! initialized). That is expected.
+//!
+//! The intent of this binary is to provide a minimal target to aid build size
+//! optimization efforts for the library.
+
+extern crate cshannon;
+
+use std::path::Path;
+
+fn main() {
+    cshannon::run(cshannon::Args {
+        command: cshannon::Command::Compress(cshannon::CompressArgs {
+            encoding_scheme: cshannon::EncodingScheme::BalancedTree,
+            tokenization_scheme: cshannon::TokenizationScheme::Grapheme,
+        }),
+        input_file: &Path::new("/tmp/non-existent-input-file"),
+        output_file: &Path::new("/tmp/non-existent-output-file"),
+    })
+    .unwrap();
+    cshannon::run(cshannon::Args {
+        command: cshannon::Command::Decompress(cshannon::DecompressArgs {}),
+        input_file: &Path::new("/tmp/non-existent-input-file"),
+        output_file: &Path::new("/tmp/non-existent-output-file"),
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Allows us to analyze anticipated bloat to a binary that includes our library.

The overall numbers are looking sensible. The largest contribution to the binary size is from `cshannon` and `std` libraries. So we don't have any unnecessary bloat from dependencies.

```sh
(base) callpraths@personal-workstation:/mnt/data/src/cshannon$ cargo bloat --release --bin minbin --crates --split-std 2>/dev/null
 File  .text     Size Crate
 4.6%  40.5% 190.9KiB cshannon
 2.5%  22.0% 103.9KiB std
 1.6%  14.3%  67.6KiB core
 0.9%   8.1%  38.0KiB gimli
 0.5%   4.4%  20.5KiB rustc_demangle
 0.3%   2.6%  12.5KiB alloc
 0.3%   2.4%  11.2KiB addr2line
 0.2%   1.9%   9.2KiB miniz_oxide
 0.1%   1.0%   4.7KiB anyhow
 0.1%   0.8%   3.8KiB unicode_segmentation
 0.0%   0.2%     984B adler2
 0.0%   0.2%     894B memchr
 0.0%   0.1%     251B minbin
 0.0%   0.1%     243B panic_abort
 0.0%   0.0%     119B compiler_builtins
 0.0%   0.0%      90B hashbrown
 0.0%   0.0%      79B object
 0.0%   0.0%      73B [Unknown]
 0.0%   0.0%      52B log
 0.0%   0.0%      24B panic_unwind
 0.0%   0.0%      24B And 1 more crates. Use -n N to show more.
11.4% 100.0% 471.5KiB .text section size, the file size is 4.1MiB
```

Digging in, looks like the largest contribution is from stack unwinding support in `std`.

```sh
(base) callpraths@personal-workstation:/mnt/data/src/cshannon$ cargo bloat --release --bin minbin 2>/dev/null
 File  .text     Size    Crate Name
 0.7%   6.0%  28.3KiB cshannon core::slice::sort::shared::smallsort::small_sort_network
 0.4%   3.3%  15.5KiB      std std::backtrace_rs::symbolize::gimli::Cache::with_global
 0.3%   2.7%  12.6KiB      std std::backtrace_rs::symbolize::gimli::Context::new
 0.2%   2.0%   9.4KiB      std gimli::read::dwarf::Unit<R>::new
 0.2%   1.9%   8.7KiB      std core::cell::once::OnceCell<T>::try_init
 0.2%   1.6%   7.7KiB cshannon cshannon::internal::compress
 0.2%   1.4%   6.5KiB      std miniz_oxide::inflate::core::decompress
 0.2%   1.3%   6.3KiB cshannon core::slice::sort::unstable::quicksort::quicksort
 0.1%   1.1%   5.1KiB      std gimli::read::unit::parse_attribute
 0.1%   0.9%   4.4KiB      std addr2line::function::Function<R>::parse_children
 0.1%   0.9%   4.2KiB cshannon core::slice::sort::unstable::quicksort::quicksort
 0.1%   0.9%   4.2KiB cshannon core::slice::sort::unstable::quicksort::quicksort
 0.1%   0.8%   3.9KiB      std gimli::read::rnglists::RngListIter<R>::next
 0.1%   0.8%   3.7KiB      std core::cell::once::OnceCell<T>::try_init
 0.1%   0.8%   3.7KiB      std std::sys::pal::unix::stack_overflow::thread_info::set_current_info
 0.1%   0.8%   3.5KiB cshannon cshannon::internal::decompress
 0.1%   0.7%   3.2KiB cshannon core::slice::sort::stable::quicksort::quicksort
 0.1%   0.7%   3.1KiB      std std::backtrace_rs::symbolize::gimli::elf::<impl std::backtrace_rs::symbolize::gimli::Mapping>::new_debug
 0.1%   0.6%   2.9KiB cshannon core::slice::sort::shared::smallsort::small_sort_general
 0.1%   0.6%   2.9KiB cshannon core::slice::sort::shared::smallsort::small_sort_general
 7.8%  68.9% 325.1KiB          And 924 smaller methods. Use -n N to show more.
11.4% 100.0% 471.5KiB          .text section size, the file size is 4.1MiB
```

At this point, I pronounce this library OK w.r.t. dependencies and size, for a toy project ;)