### PR TITLE
Prep for 0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cshannon"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "cshannon"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Prathmesh Prabhu <callpraths@gmail.com>"]
 edition = "2018"
 description = "An implementation of compression algorithms leading up to Huffman's encoding"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,14 @@
 //! });
 //! ```
 //!
+//! This library uses the logging facade from the [`log`] create.
+//! You must setup an appropriate logger in your binary's entry-point for the
+//! library to use. As an example, the primary command line binary in this
+//! package uses [`env_logger`] (see `src/bin/cli.rs`).
+//!
+//! [`log`]: https://docs.rs/log/latest/log/
+//! [`env_logger`]: https://docs.rs/env_logger/latest/env_logger/
+//!
 //! # Abstraction operation description
 //!
 //! The abstract steps in compression are as follows:


### PR DESCRIPTION
Bumping up minor version to signal breaking API changes in an unstable (pre-`1.0`) package.